### PR TITLE
Update Installation with upgrade instructions

### DIFF
--- a/getting-started/installation/index.md
+++ b/getting-started/installation/index.md
@@ -21,3 +21,10 @@ Go to _/url/to/cockpit/install_ in your favorite Browser.
 
 ---
 **Done!** You're ready to use Cockpit.
+
+## Upgrading to a newer version of Cockpit
+
+1. Download and unzip your desired version of Cockpit
+2. Override the whole cockpit directory except the `config` and the `storage` folder.
+
+That's it! 


### PR DESCRIPTION
I added the upgrade instructions to the *installation*-page in the docs. I suppose there will be other users in the future with the same question 😉 

If this isn't the preferred location for the upgrade instructions, feel free to put them somewhere else.