### PR TITLE
Added info about passing API token through headers.

### DIFF
--- a/api/token/index.md
+++ b/api/token/index.md
@@ -1,7 +1,7 @@
 uid: pid-57cd7de46c809
 type: documentation/page
 created: 2016-09-05 14:15:00
-modified: 2016-09-05 14:15:00
+modified: 2019-02-01 09:47:00
 title: API Token
 sort: 0
 
@@ -26,3 +26,29 @@ If you just want to allow to query the posts collection with the token, then the
 `/api/collections/get/posts`
 
 Or `/api/collections/get/(authors|posts)` for multiple collections.
+
+The token can be passed to the Cockpit API in three ways. 
+
+1. In a query parameter.
+2. As a `Cockpit-Token` header.
+3. As a `Bearer` token in the `Authorization` header.
+
+```javascript
+fetch('/api/collections/get/posts?token=xxtokenxx')
+.then(res=>res.json())
+.then(res => console.log(res));
+
+// Cockpit token header.
+fetch('/api/collections/get/posts', {
+    headers: { 'Cockpit-Token': 'xxtokenxx' }
+})
+.then(res=>res.json())
+.then(res => console.log(res));
+
+// Bearer token in Authorization header.
+fetch('/api/collections/get/posts', {
+    headers: { 'Authorization': 'Bearer xxtokenxx' }
+})
+.then(res=>res.json())
+.then(res => console.log(res));
+```


### PR DESCRIPTION
The docs where missing information on how to pass the API Token via headers, so this PR should fix that.  

Commits enabling the feature have been merged into the master branch of the cockpit source.

References:

Enabling the token header:  
https://github.com/agentejo/cockpit/commit/48363147a155971163d37ca169ab0390092a299c

Bearer token:
https://github.com/agentejo/cockpit/commit/e4051ab0fcd0e6ac88949731436b72e4cdfc9046