### PR TITLE
Fix wrong event names

### DIFF
--- a/api/webhooks/index.md
+++ b/api/webhooks/index.md
@@ -52,8 +52,8 @@ $body = file_get_contents('php://input');
 - _cockpit.assets.save_
 - _cockpit.assets.remove_
 - _cockpit.rest.init_
-- _cockpit.rest.authenticate_
-- _cockpit.rest.erroronrequest_
+- _cockpit.api.authenticate_
+- _cockpit.api.erroronrequest_
 - _collections.createcollection_
 - _collections.updatecollection_
 - _collections.removecollection_


### PR DESCRIPTION
Hi, I just run through all the code and realized that **cockpit.rest.authenticate** and **cockpit.rest.erroronrequest** don't exist, it's **cockpit.api.*** instead.
