### PR TITLE
add fileinfo to requirements

### DIFF
--- a/getting-started/requirements/index.md
+++ b/getting-started/requirements/index.md
@@ -9,7 +9,7 @@ sort: 1
 
 - PHP >= 7.1
 - PDO with SQLite support (or MongoDB)
-- GD, Zip extension enabled
+- GD, Zip, fileinfo extension enabled
 - Apache (with mod_rewrite enabled) or nginx
 - Any modern Browser
 


### PR DESCRIPTION
Without fileinfo extention enabled throws 500 error and message 'Something went wrong'.