### PR TITLE
Fix syntax errors in example config.php

### DIFF
--- a/reference/configuration/index.md
+++ b/reference/configuration/index.md
@@ -72,14 +72,14 @@ return [
     # use smtp to send emails
     'mailer' => [
         'from'       => 'info@mydomain.tld',
-        'transport'  => 'smtp'
+        'transport'  => 'smtp',
         'host'       => 'smtp.myhost.tld',
-        'user'       => 'username'
+        'user'       => 'username',
         'password'   => 'xxpasswordxx',
         'port'       => 25,
         'auth'       => true,
         'encryption' => '' # '', 'ssl' or 'tls'
-    ]
+    ],
 
     # Define Access-Control (CORS) settings.
     # Those are the default values. You don't need to duplicate them all.


### PR DESCRIPTION
Hey 👋

the example config.php is missing some commas, so copying and pasting doesn't really work.
I went ahead and added them.