### PR TITLE
Fix php version requirements

### DIFF
--- a/getting-started/requirements/index.md
+++ b/getting-started/requirements/index.md
@@ -7,7 +7,7 @@ sort: 1
 
 ===
 
-- PHP >= 7.1
+- PHP >= 7.3
 - PDO with SQLite support (or MongoDB)
 - GD, Zip extension enabled
 - Apache (with mod_rewrite enabled) or nginx


### PR DESCRIPTION
Hello everyone!

Thanks for the good work in first place, I appreciate it.

With this change I fixed the docs by correcting the PHP version requirements. The recent composer.json shows, that 7.3 is required, that's why I adjusted it here. (see https://github.com/agentejo/cockpit/blob/next/composer.json)

This problem was reported in https://github.com/agentejo/cockpit/issues/1474 too. I think the issue can be closed afterwards.